### PR TITLE
Add new location unit tests, 1.21.6 Advancements, and some updated logic rules

### DIFF
--- a/worlds/minecraft/Options.py
+++ b/worlds/minecraft/Options.py
@@ -8,7 +8,7 @@ class AdvancementGoal(Range):
     """Number of advancements required to spawn bosses."""
     display_name = "Advancement Goal"
     range_start = 0
-    range_end = 122
+    range_end = 136
     default = 40
 
 

--- a/worlds/minecraft/Rules.py
+++ b/worlds/minecraft/Rules.py
@@ -457,18 +457,10 @@ def get_rules_lookup(world, player: int):
                                          and state.has('Progressive Tools', player, 2)
                                          and basic_combat(world, state, player),
             "Wax On": lambda state: state.has('Campfire', player)
-                                    and has_iron_ingots(world, state, player)
-                                    and (
-                                         state.has('Progressive Resource Crafting', player, 2)
-                                         or (
-                                          can_adventure(world, state, player)
-                                          and has_explorer_maps(world, state, player)
-                                        )
-                                    ),
+                                    and has_copper_ingots(world, state, player),
             "Wax Off": lambda state: (
                                       has_copper_ingots(world, state, player)
                                       and state.has('Campfire', player)
-                                      and state.has('Progressive Resource Crafting', player, 2)
                                      )
                                      or (
                                       can_adventure(world, state, player)

--- a/worlds/minecraft/Rules.py
+++ b/worlds/minecraft/Rules.py
@@ -58,7 +58,7 @@ def can_use_anvil(world: "MinecraftWorld", state: CollectionState, player: int) 
            )
 
 
-def fortress_loot(world: "MinecraftWorld", state: CollectionState, player: int) -> bool:  # saddles, blaze rods, wither skulls
+def fortress_loot(world: "MinecraftWorld", state: CollectionState, player: int) -> bool:  # blaze rods, wither skulls
     return state.can_reach_region('Nether Fortress', player) and basic_combat(world, state, player)
 
 
@@ -318,10 +318,7 @@ def get_rules_lookup(world, player: int):
             "The Next Generation": lambda state: can_respawn_ender_dragon(world, state, player)
                                                  and can_kill_ender_dragon(world, state, player),
             "Fishy Business": lambda state: state.has("Fishing Rod", player),
-            "This Boat Has Legs": lambda state: (
-                                                    fortress_loot(world, state, player)
-                                                    or complete_raid(world, state, player)
-                                                 )
+            "This Boat Has Legs": lambda state: has_iron_ingots(world, state, player)
                                                 and state.has("Saddle", player)
                                                 and state.has("Fishing Rod", player),
             "Sniper Duel": lambda state: state.has("Archery", player),
@@ -440,10 +437,7 @@ def get_rules_lookup(world, player: int):
                                      and state.has("Bucket", player),
             "On a Rail": lambda state: has_iron_ingots(world, state, player)
                                        and state.has('Progressive Tools', player, 2),
-            "When Pigs Fly": lambda state:  (
-                                                fortress_loot(world, state, player)
-                                                or complete_raid(world, state, player)
-                                            )
+            "When Pigs Fly": lambda state:  has_iron_ingots(world, state, player)
                                             and state.has("Saddle", player)
                                             and state.has("Fishing Rod", player)
                                             and can_adventure(world, state, player),
@@ -505,10 +499,6 @@ def get_rules_lookup(world, player: int):
             "Feels Like Home": lambda state: has_iron_ingots(world, state, player)
                                              and state.has('Bucket', player)
                                              and state.has('Fishing Rod', player)
-                                             and (
-                                               fortress_loot(world, state, player)
-                                               or complete_raid(world, state, player)
-                                             )
                                              and state.has("Saddle", player),
             "Sound of Music": lambda state: state.has("Progressive Tools", player, 2)
                                             and has_iron_ingots(world, state, player)

--- a/worlds/minecraft/Rules.py
+++ b/worlds/minecraft/Rules.py
@@ -402,10 +402,10 @@ def get_rules_lookup(world, player: int):
             "Adventuring Time": lambda state: can_adventure(world, state, player)
                                               and has_iron_ingots(world, state, player)
                                               and state.has("Progressive Tools", player, 2)
-                                              and state.can_reach_region('Ocean Monument', player) # All Ocean variants except for Warm Ocean
-                                              and state.can_reach_region('Woodland Mansion', player)
-                                              and state.can_reach_region('Ancient City', player) # Dark Forest; Deep Dark
-                                              and state.can_reach_region('Trail Ruins', player), # Jungle, Birch Forest, Old Growth Birch Forest, all Taiga variants
+                                              and state.can_reach_region('Ocean Monument', player)  # Most Oceans
+                                              and state.can_reach_region('Woodland Mansion', player)  # Dark Forest
+                                              and state.can_reach_region('Ancient City', player)  # Deep Dark
+                                              and state.can_reach_region('Trail Ruins', player),  # Jungle, Birch Forest, Old Growth Birch Forest, all Taiga variants
             "Hero of the Village": lambda state: complete_raid(world, state, player),
             "Hidden in the Depths": lambda state: can_brew_potions(world, state, player)
                                                   and state.has("Bed", player)
@@ -462,12 +462,24 @@ def get_rules_lookup(world, player: int):
             "Overpowered": lambda state: has_iron_ingots(world, state, player)
                                          and state.has('Progressive Tools', player, 2)
                                          and basic_combat(world, state, player),
-            "Wax On": lambda state: has_copper_ingots(world, state, player)
-                                    and state.has('Campfire', player)
-                                    and state.has('Progressive Resource Crafting', player, 2),
-            "Wax Off": lambda state: has_copper_ingots(world, state, player)
-                                     and state.has('Campfire', player)
-                                     and state.has('Progressive Resource Crafting', player, 2),
+            "Wax On": lambda state: state.has('Campfire', player)
+                                    and has_iron_ingots(world, state, player)
+                                    and (
+                                         state.has('Progressive Resource Crafting', player, 2)
+                                         or (
+                                          can_adventure(world, state, player)
+                                          and has_explorer_maps(world, state, player)
+                                        )
+                                    ),
+            "Wax Off": lambda state: (
+                                      has_copper_ingots(world, state, player)
+                                      and state.has('Campfire', player)
+                                      and state.has('Progressive Resource Crafting', player, 2)
+                                     )
+                                     or (
+                                      can_adventure(world, state, player)
+                                      and has_explorer_maps(world, state, player)
+                                     ),
             "The Cutest Predator": lambda state: can_adventure(world, state, player)
                                                  and has_iron_ingots(world, state, player)
                                                  and state.has('Bucket', player),
@@ -640,7 +652,21 @@ def get_rules_lookup(world, player: int):
                                          and has_explorer_maps(world, state, player)
                                         ),
             "Over-Overkill": lambda state: ominous_vaults(world, state, player),
-            "Revaulting": lambda state: ominous_vaults(world, state, player)
+            "Revaulting": lambda state: ominous_vaults(world, state, player),
+            "Stay Hydrated!": lambda state: state.can_reach_region("The Nether", player)
+                                            or can_piglin_trade(world, state, player),
+            "Heart Transplanter": lambda state: can_adventure(world, state, player)
+                                                and (
+                                                 (
+                                                  basic_combat(world, state, player)
+                                                  and state.has("Progressive Resource Crafting", player, 2)
+                                                 )
+                                                 or (
+                                                  state.has("Silk Touch Book", player)
+                                                  and can_use_anvil(world, state, player)
+                                                  and can_enchant(world, state, player)
+                                                 )
+                                                )
         }
     }
     return rules_lookup

--- a/worlds/minecraft/data/excluded_locations.json
+++ b/worlds/minecraft/data/excluded_locations.json
@@ -20,7 +20,9 @@
         "Careful Restoration",
         "The Whole Pack",
         "Blowback",
-        "Over-Overkill"
+        "Over-Overkill",
+        "Stay Hydrated!",
+        "Heart Transplanter"
     ],
     "unreasonable": [
         "How Did We Get Here?",

--- a/worlds/minecraft/data/locations.json
+++ b/worlds/minecraft/data/locations.json
@@ -133,7 +133,9 @@
         "Crafters Crafting Crafters",
         "Lighten Up",
         "Over-Overkill",
-        "Revaulting"
+        "Revaulting",
+        "Stay Hydrated!",
+        "Heart Transplanter"
     ],
     "locations_by_region": {
         "Overworld": [
@@ -214,7 +216,9 @@
             "Blowback",
             "Who Needs Rockets?",
             "Crafters Crafting Crafters",
-            "Lighten Up"
+            "Lighten Up",
+            "Stay Hydrated!",
+            "Heart Transplanter"
         ],
         "The Nether": [
             "Hot Tourist Destinations",

--- a/worlds/minecraft/test/TestAdvancements.py
+++ b/worlds/minecraft/test/TestAdvancements.py
@@ -772,7 +772,7 @@ class TestAdvancements(MCTestBase):
             ["Adventuring Time", False, []],
             ["Adventuring Time", False, [], ['Progressive Weapons']],
             ["Adventuring Time", False, [], ['Progressive Resource Crafting']],
-            ["Adventuring Time", False, [], ['Progressive Tools', 'Progressive Tools']],
+            ["Adventuring Time", False, ['Progressive Tools'], ['Progressive Tools', 'Progressive Tools']],
             ["Adventuring Time", True, ['Progressive Weapons', 'Progressive Resource Crafting',
                                         'Progressive Tools', 'Progressive Tools']],
             ])
@@ -1161,18 +1161,35 @@ class TestAdvancements(MCTestBase):
         self.run_location_tests([
             ["Wax On", False, []],
             ["Wax On", False, [], ["Progressive Tools"]],
+            ["Wax On", False, [], ["Progressive Resource Crafting"]],
             ["Wax On", False, [], ["Campfire"]],
-            ["Wax On", False, ["Progressive Resource Crafting"], ["Progressive Resource Crafting"]],
-            ["Wax On", True, ["Progressive Tools", "Progressive Resource Crafting", "Progressive Resource Crafting", "Campfire"]],
+            ["Wax On", False, ["Progressive Resource Crafting"], ["Progressive Resource Crafting",
+                                                                  "Progressive Weapons"]],
+            ["Wax On", False, ["Progressive Resource Crafting", "Progressive Tools"], ["Progressive Resource Crafting",
+                                                                                       "Progressive Tools",
+                                                                                       "Progressive Tools"]],
+            ["Wax On", True, ["Campfire", "Progressive Tools",
+                              "Progressive Resource Crafting", "Progressive Resource Crafting"]],
+            ["Wax On", True, ["Campfire", "Progressive Resource Crafting",
+                              "Progressive Tools", "Progressive Tools", "Progressive Weapons"]],
             ])
 
     def test_42093(self):
         self.run_location_tests([
             ["Wax Off", False, []],
             ["Wax Off", False, [], ["Progressive Tools"]],
-            ["Wax Off", False, [], ["Campfire"]],
-            ["Wax Off", False, ["Progressive Resource Crafting"], ["Progressive Resource Crafting"]],
-            ["Wax Off", True, ["Progressive Tools", "Progressive Resource Crafting", "Progressive Resource Crafting", "Campfire"]],
+            ["Wax Off", False, [], ["Progressive Resource Crafting"]],
+            ["Wax Off", False, [], ["Campfire", "Progressive Weapons"]],
+            ["Wax Off", False, ["Progressive Tools"], ["Campfire", "Progressive Tools", "Progressive Tools"]],
+            ["Wax Off", False, ["Progressive Resource Crafting"], ["Progressive Resource Crafting",
+                                                                   "Progressive Weapons"]],
+            ["Wax Off", False, ["Progressive Resource Crafting", "Progressive Tools"], ["Progressive Resource Crafting",
+                                                                                        "Progressive Tools",
+                                                                                        "Progressive Tools"]],
+            ["Wax Off", True, ["Progressive Tools",
+                               "Progressive Resource Crafting", "Progressive Resource Crafting", "Campfire"]],
+            ["Wax Off", True, ["Progressive Resource Crafting",
+                               "Progressive Tools", "Progressive Tools", "Progressive Weapons"]]
             ])
 
     def test_42094(self):
@@ -1408,4 +1425,307 @@ class TestAdvancements(MCTestBase):
             ["You've Got a Friend in Me", False, [], ["Campfire", "Progressive Resource Crafting"]],
             ["You've Got a Friend in Me", True, ["Progressive Weapons", "Campfire"]],
             ["You've Got a Friend in Me", True, ["Progressive Weapons", "Progressive Resource Crafting"]],
+            ])
+
+    # ocean ruins, brush
+    def test_42114(self):
+        self.run_location_tests([
+            ["Smells Interesting", False, []],
+            ["Smells Interesting", False, [], ["Brush"]],
+            ["Smells Interesting", False, [], ["Progressive Weapons"]],
+            ["Smells Interesting", False, [], ["Progressive Resource Crafting"]],
+            ["Smells Interesting", False, [], ["Progressive Tools"]],
+            ["Smells Interesting", True, ["Brush", "Progressive Weapons",
+                                          "Progressive Resource Crafting", "Progressive Tools"]],
+            ])
+
+    # ocean ruins, brush
+    def test_42115(self):
+        self.run_location_tests([
+            ["Little Sniffs", False, []],
+            ["Little Sniffs", False, [], ["Brush"]],
+            ["Little Sniffs", False, [], ["Progressive Weapons"]],
+            ["Little Sniffs", False, [], ["Progressive Resource Crafting"]],
+            ["Little Sniffs", False, [], ["Progressive Tools"]],
+            ["Little Sniffs", True, ["Brush", "Progressive Weapons",
+                                     "Progressive Resource Crafting", "Progressive Tools"]],
+            ])
+
+    # ocean ruins, brush
+    def test_42116(self):
+        self.run_location_tests([
+            ["Planting the Past", False, []],
+            ["Planting the Past", False, [], ["Brush"]],
+            ["Planting the Past", False, [], ["Progressive Weapons"]],
+            ["Planting the Past", False, [], ["Progressive Resource Crafting"]],
+            ["Planting the Past", False, [], ["Progressive Tools"]],
+            ["Planting the Past", True, ["Brush", "Progressive Weapons",
+                                         "Progressive Resource Crafting", "Progressive Tools"]],
+            ])
+
+    def test_42117(self):
+        self.run_location_tests([
+            ["Crafting a New Look", False, []],
+            ["Crafting a New Look", False, [], ["Progressive Tools"]],
+            ["Crafting a New Look", False, [], ["Progressive Resource Crafting"]],
+            ["Crafting a New Look", False, [], ["Progressive Weapons"]],
+            ["Crafting a New Look", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools",
+                                                                   "Progressive Armor", "Shield", "Brush"]],
+            ["Crafting a New Look", True, ["Progressive Resource Crafting", "Progressive Weapons",
+                                           "Progressive Tools", "Progressive Armor"], []],
+            ["Crafting a New Look", True, ["Progressive Resource Crafting", "Progressive Weapons",
+                                           "Progressive Tools", "Shield"], []],
+            ["Crafting a New Look", True, ["Progressive Resource Crafting", "Progressive Weapons",
+                                           "Progressive Tools", "Progressive Tools"], []],
+            ["Crafting a New Look", True, ["Progressive Resource Crafting", "Progressive Weapons",
+                                           "Progressive Tools", "Brush"], []],
+            ])
+
+    def test_42118(self):
+        self.run_location_tests([
+            ["Smithing with Style", False, []],
+            ["Smithing with Style", False, [], ["Progressive Resource Crafting"]],
+            ["Smithing with Style", False, [], ["Brush"]],
+            ["Smithing with Style", False, [], ["Progressive Weapons"]],
+            ["Smithing with Style", False, ["3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls"], ["3 Ender Pearls"]],
+            ["Smithing with Style", False, [], ["Brewing"]],
+            ["Smithing with Style", False, [], ["Flint and Steel"]],
+            ["Smithing with Style", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Smithing with Style", False, [], ["Progressive Armor", "Shield"]],
+            ["Smithing with Style", False, ["Progressive Tools", "Progressive Tools"], ["Bucket", "Progressive Tools"]],
+            ["Smithing with Style", False, ["Progressive Tools", "Progressive Tools"], ["Progressive Tools",
+                                                                                        "Fishing Rod"]],
+            ["Smithing with Style", False, ["Progressive Tools", "Progressive Tools"], ["Progressive Tools", "Bucket"]],
+            ["Smithing with Style", False, [], ["Bucket", "Fishing Rod"]],
+            ["Smithing with Style", False, [], ["Bucket", "Bottles"]],
+            ["Smithing with Style", False, [], ["Fishing Rod", "Enchanting"]],
+            ["Smithing with Style", False, [], ["Bottles", "Enchanting"]],
+            ["Smithing with Style", True, ["Progressive Tools", "Progressive Tools",
+                                           "Progressive Resource Crafting", "Brush", "Progressive Weapons", "Brewing",
+                                           "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls",
+                                           "Flint and Steel", "Progressive Armor", "Bucket", "Bottles", "Fishing Rod"]],
+            ["Smithing with Style", True, ["Progressive Tools", "Progressive Tools",
+                                           "Progressive Resource Crafting", "Brush", "Progressive Weapons", "Brewing",
+                                           "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls",
+                                           "Flint and Steel", "Shield", "Bucket", "Bottles", "Fishing Rod"]],
+            ["Smithing with Style", True, ["Progressive Tools", "Progressive Tools",
+                                           "Progressive Resource Crafting", "Brush", "Progressive Weapons", "Brewing",
+                                           "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls",
+                                           "Flint and Steel", "Progressive Armor", "Progressive Tools",
+                                           "Bottles", "Fishing Rod"]],
+            ["Smithing with Style", True, ["Progressive Tools", "Progressive Tools", "Progressive Tools",
+                                           "Progressive Resource Crafting", "Brush", "Progressive Weapons", "Brewing",
+                                           "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls",
+                                           "Flint and Steel", "Shield", "Bottles", "Fishing Rod"]],
+            ["Smithing with Style", True, ["Progressive Tools", "Progressive Tools", "Progressive Tools",
+                                           "Progressive Resource Crafting", "Brush", "Progressive Weapons", "Brewing",
+                                           "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls",
+                                           "Flint and Steel", "Progressive Armor", "Bucket", "Enchanting"]],
+            ["Smithing with Style", True, ["Progressive Tools", "Progressive Tools", "Progressive Tools",
+                                           "Progressive Resource Crafting", "Brush", "Progressive Weapons", "Brewing",
+                                           "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls", "3 Ender Pearls",
+                                           "Flint and Steel", "Shield", "Bucket", "Enchanting"]],
+            ])
+
+    def test_42119(self):
+        self.run_location_tests([
+            ["Respecting the Remnants", False, []],
+            ["Respecting the Remnants", False, [], ["Progressive Tools"]],
+            ["Respecting the Remnants", False, [], ["Progressive Resource Crafting"]],
+            ["Respecting the Remnants", False, [], ["Brush"]],
+            ["Respecting the Remnants", False, [], ["Progressive Weapons"]],
+            ["Respecting the Remnants", True, ["Progressive Tools", "Progressive Resource Crafting",
+                                               "Brush", "Progressive Weapons"]],
+            ])
+
+    def test_42120(self):
+        self.run_location_tests([
+            ["Careful Restoration", False, []],
+            ["Careful Restoration", False, [], ["Progressive Tools"]],
+            ["Careful Restoration", False, [], ["Progressive Resource Crafting"]],
+            ["Careful Restoration", False, [], ["Brush"]],
+            ["Careful Restoration", False, [], ["Progressive Weapons"]],
+            ["Careful Restoration", True, ["Progressive Tools", "Progressive Resource Crafting",
+                                           "Brush", "Progressive Weapons"]],
+            ])
+
+    def test_42121(self):
+        self.run_location_tests([
+            ["The Power of Books", False, []],
+            ["The Power of Books", False, [], ["Progressive Resource Crafting"]],
+            ["The Power of Books", False, [], ["Flint and Steel"]],
+            ["The Power of Books", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["The Power of Books", False, ["Progressive Tools", "Progressive Tools"], ["Progressive Tools", "Bucket"]],
+            ["The Power of Books", True, ["Progressive Resource Crafting", "Flint and Steel",
+                                          "Progressive Tools", "Progressive Tools", "Progressive Tools"]],
+            ["The Power of Books", True, ["Progressive Resource Crafting", "Flint and Steel",
+                                          "Progressive Tools", "Progressive Tools", "Bucket"]],
+            ])
+
+    def test_42122(self):
+        self.run_location_tests([
+            ["Isn't It Scute?", False, []],
+            ["Isn't It Scute?", False, [], ["Progressive Weapons"]],
+            ["Isn't It Scute?", False, [], ["Progressive Resource Crafting"]],
+            ["Isn't It Scute?", False, [], ["Progressive Tools"]],
+            ["Isn't It Scute?", False, [], ["Brush"]],
+            ["Isn't It Scute?", True, ["Progressive Weapons", "Progressive Resource Crafting",
+                                       "Progressive Tools", "Brush"]],
+            ])
+
+    def test_42123(self):
+        self.run_location_tests([
+            ["Shear Brilliance", False, []],
+            ["Shear Brilliance", False, [], ["Progressive Weapons"]],
+            ["Shear Brilliance", False, [], ["Progressive Resource Crafting"]],
+            ["Shear Brilliance", False, [], ["Progressive Tools"]],
+            ["Shear Brilliance", False, [], ["Brush"]],
+            ["Shear Brilliance", True, ["Progressive Weapons", "Progressive Resource Crafting",
+                                        "Progressive Tools", "Brush"]],
+            ])
+
+    def test_42124(self):
+        self.run_location_tests([
+            ["Good as New", False, []],
+            ["Good as New", False, [], ["Progressive Weapons"]],
+            ["Good as New", False, [], ["Progressive Resource Crafting"]],
+            ["Good as New", False, [], ["Progressive Tools"]],
+            ["Good as New", False, [], ["Brush"]],
+            ["Good as New", True, ["Progressive Weapons", "Progressive Resource Crafting",
+                                   "Progressive Tools", "Brush"]],
+            ])
+
+    def test_42125(self):
+        self.run_location_tests([
+            ["The Whole Pack", False, []],
+            ["The Whole Pack", False, [], ["Progressive Weapons"]],
+            ["The Whole Pack", False, [], ["Progressive Resource Crafting", "Campfire"]],
+            ["The Whole Pack", True, ["Progressive Weapons", "Progressive Resource Crafting"]],
+            ["The Whole Pack", True, ["Progressive Weapons", "Campfire"]],
+            ])
+
+    def test_42126(self):
+        self.run_location_tests([
+            ["Minecraft: Trial(s) Edition", False, []],
+            ["Minecraft: Trial(s) Edition", False, [], ["Progressive Weapons"]],
+            ["Minecraft: Trial(s) Edition", False, [], ["Progressive Resource Crafting"]],
+            ["Minecraft: Trial(s) Edition", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Minecraft: Trial(s) Edition", True, ["Progressive Tools", "Progressive Tools",
+                                                   "Progressive Weapons", "Progressive Resource Crafting"]],
+            ])
+
+    def test_42127(self):
+        self.run_location_tests([
+            ["Under Lock and Key", False, []],
+            ["Under Lock and Key", False, [], ["Progressive Weapons"]],
+            ["Under Lock and Key", False, [], ["Progressive Resource Crafting"]],
+            ["Under Lock and Key", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Under Lock and Key", False, [], ["Progressive Armor", "Shield"]],
+            ["Under Lock and Key", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+                                          "Progressive Resource Crafting", "Progressive Armor"]],
+            ["Under Lock and Key", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+                                          "Progressive Resource Crafting", "Shield"]],
+            ])
+
+    def test_42128(self):
+        self.run_location_tests([
+            ["Blowback", False, []],
+            ["Blowback", False, [], ["Progressive Weapons"]],
+            ["Blowback", False, [], ["Progressive Resource Crafting"]],
+            ["Blowback", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Blowback", False, [], ["Progressive Armor", "Shield"]],
+            ["Blowback", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+                                "Progressive Resource Crafting", "Progressive Armor"]],
+            ["Blowback", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+                                "Progressive Resource Crafting", "Shield"]],
+            ])
+
+    def test_42129(self):
+        self.run_location_tests([
+            ["Who Needs Rockets?", False, []],
+            ["Who Needs Rockets?", False, [], ["Progressive Weapons"]],
+            ["Who Needs Rockets?", False, [], ["Progressive Resource Crafting"]],
+            ["Who Needs Rockets?", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Who Needs Rockets?", False, [], ["Progressive Armor", "Shield"]],
+            ["Who Needs Rockets?", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+                                          "Progressive Resource Crafting", "Progressive Armor"]],
+            ["Who Needs Rockets?", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+                                          "Progressive Resource Crafting", "Shield"]],
+            ])
+
+    def test_42130(self):
+        self.run_location_tests([
+            ["Crafters Crafting Crafters", False, []],
+            ["Crafters Crafting Crafters", False, [], ["Progressive Resource Crafting"]],
+            ["Crafters Crafting Crafters", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Crafters Crafting Crafters", True, ["Progressive Tools", "Progressive Tools",
+                                                  "Progressive Resource Crafting"]],
+            ])
+
+    def test_42131(self):
+        self.run_location_tests([
+            ["Lighten Up", False, []],
+            ["Lighten Up", False, [], ["Progressive Weapons"]],
+            ["Lighten Up", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Lighten Up", False, [], ["Progressive Resource Crafting"]],
+            ["Lighten Up", True, ["Progressive Tools", "Progressive Tools",
+                                  "Progressive Weapons", "Progressive Resource Crafting"]],
+            ])
+
+    def test_42132(self):
+        self.run_location_tests([
+            ["Over-Overkill", False, []],
+            ["Over-Overkill", False, [], ["Progressive Resource Crafting"]],
+            ["Over-Overkill", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Over-Overkill", False, ["Progressive Weapons"], ["Progressive Weapons", "Progressive Weapons"]],
+            ["Over-Overkill", False, [], ["Progressive Armor"]],
+            ["Over-Overkill", False, [], ["Shield"]],
+            ["Over-Overkill", True, ["Progressive Resource Crafting", "Progressive Tools", "Progressive Tools",
+                                     "Progressive Weapons", "Progressive Weapons", "Progressive Armor", "Shield"]],
+            ])
+
+    def test_42133(self):
+        self.run_location_tests([
+            ["Revaulting", False, []],
+            ["Revaulting", False, [], ["Progressive Resource Crafting"]],
+            ["Revaulting", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Revaulting", False, ["Progressive Weapons"], ["Progressive Weapons", "Progressive Weapons"]],
+            ["Revaulting", False, [], ["Progressive Armor"]],
+            ["Revaulting", False, [], ["Shield"]],
+            ["Revaulting", True, ["Progressive Resource Crafting", "Progressive Tools", "Progressive Tools",
+                                  "Progressive Weapons", "Progressive Weapons", "Progressive Armor", "Shield"]],
+            ])
+
+    def test_42134(self):
+        self.run_location_tests([
+            ["Stay Hydrated!", False, []],
+            ["Stay Hydrated!", False, [], ["Progressive Resource Crafting"]],
+            ["Stay Hydrated!", False, [], ["Progressive Tools"]],
+            ["Stay Hydrated!", False, [], ["Flint and Steel"]],
+            ["Stay Hydrated!", False, ["Progressive Tools", "Progressive Tools"], ["Progressive Tools", "Bucket"]],
+            ["Stay Hydrated!", True, ["Progressive Resource Crafting", "Flint and Steel",
+                                      "Progressive Tools", "Progressive Tools", "Progressive Tools"]],
+            ["Stay Hydrated!", True, ["Progressive Resource Crafting", "Flint and Steel",
+                                      "Progressive Tools", "Bucket"]],
+            ])
+
+    def test_42135(self):
+        self.run_location_tests([
+            ["Heart Transplanter", False, []],
+            ["Heart Transplanter", False, [], ["Progressive Weapons"]],
+            ["Heart Transplanter", False, [], ["Progressive Tools"]],
+            ["Heart Transplanter", False, ["Progressive Resource Crafting"], ["Progressive Resource Crafting"]],
+            ["Heart Transplanter", False, [], ["Progressive Armor", "Shield", "Silk Touch Book"]],
+            ["Heart Transplanter", False, [], ["Progressive Armor", "Shield", "Enchanting"]],
+            ["Heart Transplanter", False, ["Progressive Tools", "Progressive Tools"], ["Progressive Tools",
+                                                                                       "Progressive Armor", "Shield"]],
+            ["Heart Transplanter", True, ["Progressive Resource Crafting", "Progressive Resource Crafting",
+                                          "Progressive Weapons", "Progressive Armor",
+                                          "Progressive Tools"]],
+            ["Heart Transplanter", True, ["Progressive Resource Crafting", "Progressive Resource Crafting",
+                                          "Progressive Weapons", "Shield",
+                                          "Progressive Tools"]],
+            ["Heart Transplanter", True, ["Progressive Resource Crafting", "Progressive Resource Crafting",
+                                          "Progressive Weapons", "Enchanting", "Silk Touch Book",
+                                          "Progressive Tools", "Progressive Tools", "Progressive Tools"]],
             ])

--- a/worlds/minecraft/test/TestAdvancements.py
+++ b/worlds/minecraft/test/TestAdvancements.py
@@ -1151,15 +1151,7 @@ class TestAdvancements(MCTestBase):
             ["Wax On", False, [], ["Progressive Tools"]],
             ["Wax On", False, [], ["Progressive Resource Crafting"]],
             ["Wax On", False, [], ["Campfire"]],
-            ["Wax On", False, ["Progressive Resource Crafting"], ["Progressive Resource Crafting",
-                                                                  "Progressive Weapons"]],
-            ["Wax On", False, ["Progressive Resource Crafting", "Progressive Tools"], ["Progressive Resource Crafting",
-                                                                                       "Progressive Tools",
-                                                                                       "Progressive Tools"]],
-            ["Wax On", True, ["Campfire", "Progressive Tools",
-                              "Progressive Resource Crafting", "Progressive Resource Crafting"]],
-            ["Wax On", True, ["Campfire", "Progressive Resource Crafting",
-                              "Progressive Tools", "Progressive Tools", "Progressive Weapons"]],
+            ["Wax On", True, ["Progressive Resource Crafting", "Progressive Tools", "Campfire"]],
             ])
 
     def test_42093(self):
@@ -1169,15 +1161,9 @@ class TestAdvancements(MCTestBase):
             ["Wax Off", False, [], ["Progressive Resource Crafting"]],
             ["Wax Off", False, [], ["Campfire", "Progressive Weapons"]],
             ["Wax Off", False, ["Progressive Tools"], ["Campfire", "Progressive Tools", "Progressive Tools"]],
-            ["Wax Off", False, ["Progressive Resource Crafting"], ["Progressive Resource Crafting",
-                                                                   "Progressive Weapons"]],
-            ["Wax Off", False, ["Progressive Resource Crafting", "Progressive Tools"], ["Progressive Resource Crafting",
-                                                                                        "Progressive Tools",
-                                                                                        "Progressive Tools"]],
-            ["Wax Off", True, ["Progressive Tools",
-                               "Progressive Resource Crafting", "Progressive Resource Crafting", "Campfire"]],
-            ["Wax Off", True, ["Progressive Resource Crafting",
-                               "Progressive Tools", "Progressive Tools", "Progressive Weapons"]]
+            ["Wax Off", True, ["Progressive Resource Crafting", "Progressive Tools", "Campfire"]],
+            ["Wax Off", True, ["Progressive Resource Crafting", "Progressive Tools", "Progressive Tools",
+                               "Progressive Weapons"]]
             ])
 
     def test_42094(self):

--- a/worlds/minecraft/test/TestAdvancements.py
+++ b/worlds/minecraft/test/TestAdvancements.py
@@ -1099,9 +1099,11 @@ class TestAdvancements(MCTestBase):
             ["When Pigs Fly", False, []],
             ["When Pigs Fly", False, [], ['Progressive Resource Crafting']],
             ["When Pigs Fly", False, [], ['Progressive Tools']],
+            ["When Pigs Fly", False, [], ['Progressive Weapons']],
             ["When Pigs Fly", False, [], ['Fishing Rod']],
             ["When Pigs Fly", False, [], ['Saddle']],
-            ["When Pigs Fly", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Fishing Rod']],
+            ["When Pigs Fly", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools',
+                                     'Fishing Rod', 'Progressive Weapons']],
             ])
 
     def test_42089(self):

--- a/worlds/minecraft/test/TestAdvancements.py
+++ b/worlds/minecraft/test/TestAdvancements.py
@@ -210,15 +210,11 @@ class TestAdvancements(MCTestBase):
             ["This Boat Has Legs", False, [], ['Progressive Resource Crafting']],
             ["This Boat Has Legs", False, [], ['Flint and Steel']],
             ["This Boat Has Legs", False, [], ['Progressive Tools']],
-            ["This Boat Has Legs", False, [], ['Progressive Weapons']],
-            ["This Boat Has Legs", False, [], ['Progressive Armor', 'Shield']],
             ["This Boat Has Legs", False, [], ['Fishing Rod']],
             ["This Boat Has Legs", False, [], ['Saddle']],
             ["This Boat Has Legs", False, ['Progressive Tools', 'Progressive Tools'], ['Bucket', 'Progressive Tools']],
-            ["This Boat Has Legs", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Progressive Weapons', 'Progressive Armor', 'Flint and Steel', 'Bucket', 'Fishing Rod']],
-            ["This Boat Has Legs", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Progressive Weapons', 'Progressive Armor', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools', 'Fishing Rod']],
-            ["This Boat Has Legs", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Progressive Weapons', 'Shield', 'Flint and Steel', 'Bucket', 'Fishing Rod']],
-            ["This Boat Has Legs", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Progressive Weapons', 'Shield', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools', 'Fishing Rod']],
+            ["This Boat Has Legs", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Fishing Rod']],
+            ["This Boat Has Legs", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools', 'Fishing Rod']],
             ])
 
     def test_42016(self):
@@ -1103,17 +1099,9 @@ class TestAdvancements(MCTestBase):
             ["When Pigs Fly", False, []],
             ["When Pigs Fly", False, [], ['Progressive Resource Crafting']],
             ["When Pigs Fly", False, [], ['Progressive Tools']],
-            ["When Pigs Fly", False, [], ['Progressive Weapons']],
-            ["When Pigs Fly", False, [], ['Progressive Armor', 'Shield']],
             ["When Pigs Fly", False, [], ['Fishing Rod']],
             ["When Pigs Fly", False, [], ['Saddle']],
-            ["When Pigs Fly", False, ['Progressive Weapons'], ['Flint and Steel', 'Progressive Weapons', 'Progressive Weapons']],
-            ["When Pigs Fly", False, ['Progressive Tools', 'Progressive Tools', 'Progressive Weapons'], ['Bucket', 'Progressive Tools', 'Progressive Weapons', 'Progressive Weapons']],
-            ["When Pigs Fly", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Progressive Weapons', 'Progressive Armor', 'Fishing Rod']],
-            ["When Pigs Fly", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools', 'Progressive Weapons', 'Progressive Armor', 'Fishing Rod']],
-            ["When Pigs Fly", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Progressive Weapons', 'Shield', 'Fishing Rod']],
-            ["When Pigs Fly", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools', 'Progressive Weapons', 'Shield', 'Fishing Rod']],
-            ["When Pigs Fly", True, ['Saddle', 'Progressive Weapons', 'Progressive Weapons', 'Progressive Armor', 'Shield', 'Progressive Resource Crafting', 'Progressive Tools', 'Fishing Rod']],
+            ["When Pigs Fly", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Fishing Rod']],
             ])
 
     def test_42089(self):
@@ -1311,20 +1299,17 @@ class TestAdvancements(MCTestBase):
             ["Caves & Cliffs", True, ["Progressive Resource Crafting", "Progressive Tools", "Progressive Tools", "Bucket"]],
             ])
 
-    # bucket, fishing rod, saddle, combat
+    # bucket, fishing rod, saddle
     def test_42104(self):
         self.run_location_tests([
             ["Feels Like Home", False, []],
             ["Feels Like Home", False, [], ['Progressive Resource Crafting']],
             ["Feels Like Home", False, [], ['Progressive Tools']],
-            ["Feels Like Home", False, [], ['Progressive Weapons']],
-            ["Feels Like Home", False, [], ['Progressive Armor', 'Shield']],
             ["Feels Like Home", False, [], ['Fishing Rod']],
             ["Feels Like Home", False, [], ['Saddle']],
             ["Feels Like Home", False, [], ['Bucket']],
             ["Feels Like Home", False, [], ['Flint and Steel']],
-            ["Feels Like Home", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Progressive Weapons', 'Progressive Armor', 'Fishing Rod']],
-            ["Feels Like Home", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Progressive Weapons', 'Shield', 'Fishing Rod']],
+            ["Feels Like Home", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Fishing Rod']],
             ])
 
     # iron pick, combat


### PR DESCRIPTION
## What is this fixing or adding?
Added support for the two Advancements introduced in 1.21.6, "Stay Hydrated!" and "Heart Transplanter". Added tests for all of the Advancements added in 1.20 and beyond. Increased the cap for the Advancement Goal option to 136 to account for all of the newly added Advancements. Changed the rules for Wax On and Wax Off to account for the existence of Trial Chambers and the new ability to craft Copper Doors with Copper Ingots, and updated their unit tests to match. Changed the rules for locations that require Saddles so that they no longer expect them to be looted. Made some other minor adjustments.

As a note, some of these logic rule changes are predicated on certain mod changes:
- The new Block of Resin is expected to require tier 2 Progressive Resource Crafting in order to craft, matching with the other resource blocks.
- Saddle is expected to now unlock the Saddle recipe rather than giving one to the player directly, due to them now being able to be crafted.

## How was this tested?
Ran the unit tests and generated some games. All tests passed and I did not notice any issues with generation. I also tested in-game to make sure that Copper Doors could be used for Wax On and Wax Off, but have not done any further playtesting at this time.
