### PR TITLE
making linux work

### DIFF
--- a/worlds/minecraft/MinecraftClient.py
+++ b/worlds/minecraft/MinecraftClient.py
@@ -17,7 +17,6 @@ from collections import defaultdict
 from enum import Enum
 from math import floor, log
 from queue import Queue
-from tkinter import filedialog
 from typing import List, Optional, TYPE_CHECKING, Any, TypedDict
 
 import Utils
@@ -282,8 +281,10 @@ class MinecraftClient(MDApp):
         self.apmc_path = path
         if self.apmc_path is None:
             # TODO: Replace filedialog from KTinker with MDDialog?
-            self.apmc_path = filedialog.askopenfilename(title="Choose AP Minecraft file",
-                                                        filetypes=(("Archipelago Minecraft", "*.apmc"),))
+            # self.apmc_path = filedialog.askopenfilename(title="Choose AP Minecraft file",
+            #                                             filetypes=(("Archipelago Minecraft", "*.apmc"),))
+            self.apmc_path = Utils.open_filename(title="Choose AP Minecraft file",
+                                filetypes=(("Archipelago Minecraft", "*.apmc"),))
         if self.apmc_path is None or self.apmc_path == "" or os.path.isfile(self.apmc_path) is False:
             return
 
@@ -503,7 +504,8 @@ class FolderOption(TextOption):
 
     def button_press(self):
         # TODO: Replace filedialog from KTinker with MDDialog?
-        new_dir = filedialog.askdirectory(title="Choose Server Directory", initialdir=self.options.server_directory)
+        # new_dir = filedialog.askdirectory(title="Choose Server Directory", initialdir=self.options.server_directory)
+        new_dir = Utils.open_directory(title="Choose Server Directory")
         if new_dir:
             self.value = new_dir
 

--- a/worlds/minecraft/downloader/Java.py
+++ b/worlds/minecraft/downloader/Java.py
@@ -1,4 +1,6 @@
 import logging
+import shutil
+import tempfile
 
 from . import StepsStep, SyncStep
 from .Utilities import DownloadStep, FetchStep, jre_paths
@@ -6,6 +8,7 @@ from Utils import is_windows, is_linux
 import os
 import zipfile
 import platform
+import tarfile
 from typing import TypedDict, Any
 
 
@@ -104,24 +107,36 @@ class DownloadJava(StepsStep):
             return
 
         self.logger.info(f"Extracting Java {self.version}")
-        with zipfile.ZipFile(self.zip_path, 'r') as zip_ref:
-            subfolder = zip_ref.namelist()[0]
-            for entry in zip_ref.infolist()[1:]:
-                if entry.is_dir():
-                    continue
-                relative = entry.filename[len(subfolder):]
-                filepath = os.path.join(self.outpath, *relative.split("/"))
-                dirpath = os.path.dirname(filepath)
-                os.makedirs(dirpath, exist_ok=True)
-                with open(filepath, 'wb') as file:
-                    file.write(zip_ref.read(entry.filename))
+        # TODO: this probably also needs a mac flow, for .pkg files
+        if is_linux:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                with tarfile.open(self.zip_path, 'r') as tarball:
+                    tarball.extractall(temp_dir, filter='tar')
+                    items = os.listdir(temp_dir)
+                    if len(items) == 1 and os.path.isdir(os.path.join(temp_dir, items[0])):
+                        original_dir = os.path.join(temp_dir, items[0])
+                    else:
+                        original_dir = temp_dir
+                shutil.copytree(original_dir, self.outpath, dirs_exist_ok=True)
+        else:
+            with zipfile.ZipFile(self.zip_path, 'r') as zip_ref:
+                subfolder = zip_ref.namelist()[0]
+                for entry in zip_ref.infolist()[1:]:
+                    if entry.is_dir():
+                        continue
+                    relative = entry.filename[len(subfolder):]
+                    filepath = os.path.join(self.outpath, *relative.split("/"))
+                    dirpath = os.path.dirname(filepath)
+                    os.makedirs(dirpath, exist_ok=True)
+                    with open(filepath, 'wb') as file:
+                        file.write(zip_ref.read(entry.filename))
 
         os.remove(self.zip_path)
 
 def get_java_path(to: str, version: int) -> str:
     jre = jre_paths[version]
 
-    bin = "javaw.exe" if is_windows else "javaw" if is_linux else None
+    bin = "java.exe" if is_windows else "java" if is_linux else None
     if not bin:
         raise Exception("Unsupported operating system for Java path retrieval")
 

--- a/worlds/minecraft/downloader/Java.py
+++ b/worlds/minecraft/downloader/Java.py
@@ -136,7 +136,7 @@ class DownloadJava(StepsStep):
 def get_java_path(to: str, version: int) -> str:
     jre = jre_paths[version]
 
-    bin = "java.exe" if is_windows else "java" if is_linux else None
+    bin = "javaw.exe" if is_windows else "java" if is_linux else None
     if not bin:
         raise Exception("Unsupported operating system for Java path retrieval")
 


### PR DESCRIPTION
Linux JREs are bundled as gzipped tarballs, not zips, and so require a different code flow.  Additionally, javaw doesn't exist on linux, because it doesn't need to, so the resulting executable should just be java.

The setup also pretty much doesn't work for mac atm, not sure how mac works personally though.

Also, tkinter doesn't seem to like to work when opened within kivy, so switched to calling the AP helpers in Utils.