### PR TITLE
Add Trial Chamber Structure Compasses + Misc. Fixes

### DIFF
--- a/worlds/minecraft/Rules.py
+++ b/worlds/minecraft/Rules.py
@@ -96,11 +96,6 @@ def enter_stronghold(world: "MinecraftWorld", state: CollectionState, player: in
     return state.has('Blaze Rods', player) and state.has('Brewing', player) and state.has('3 Ender Pearls', player)
 
 
-def has_explorer_maps(world: "MinecraftWorld", state: CollectionState, player: int) -> bool:
-    return (overworld_villager(world, state, player) and state.has("Progressive Tools", player, 2) and
-            has_iron_ingots(world, state, player))
-
-
 # Difficulty-dependent functions
 def combat_difficulty(world: "MinecraftWorld", state: CollectionState, player: int) -> str:
     return world.options.combat_difficulty.current_key
@@ -135,9 +130,8 @@ def basic_combat(world: "MinecraftWorld", state: CollectionState, player: int) -
 
 
 def ominous_vaults(world: "MinecraftWorld", state: CollectionState, player: int) -> bool:
-    trial_chambers = (has_explorer_maps(world, state, player) and can_adventure(world, state, player))
     if combat_difficulty(world, state, player) == 'easy':
-        return (trial_chambers
+        return (state.can_reach_region("Pillager Outpost", player)
                 and state.has('Progressive Weapons', player, 3)
                 and state.has('Progressive Armor', player, 2)
                 and state.has('Shield', player)
@@ -145,7 +139,7 @@ def ominous_vaults(world: "MinecraftWorld", state: CollectionState, player: int)
                 and has_iron_ingots(world, state, player)
                )
     elif combat_difficulty(world, state, player) == 'hard':
-        return (trial_chambers
+        return (state.can_reach_region("Pillager Outpost", player)
                 and state.has('Progressive Weapons', player, 2)
                 and has_iron_ingots(world, state, player)
                 and (
@@ -153,7 +147,7 @@ def ominous_vaults(world: "MinecraftWorld", state: CollectionState, player: int)
                         or state.has('Shield', player)
                 )
                )
-    return (trial_chambers
+    return (state.can_reach_region("Pillager Outpost", player)
             and state.has('Progressive Weapons', player, 2)
             and has_iron_ingots(world, state, player)
             and state.has('Progressive Armor', player)
@@ -281,6 +275,8 @@ def get_rules_lookup(world, player: int):
                                        and has_structure_compass(world, state, "Deep Dark", player),
             "Ruins": lambda state: can_adventure(world, state, player)
                                    and has_structure_compass(world, state, "Ruins", player),
+            "Underground": lambda state: can_adventure(world, state, player) and state.has("Progressive Tools", player)
+                                         and has_structure_compass(world, state, "Underground", player)
         },
         "locations": {
             "Ender Dragon": lambda state: can_respawn_ender_dragon(world, state, player)
@@ -303,10 +299,10 @@ def get_rules_lookup(world, player: int):
                                                  and state.has("Fishing Rod", player)  # Water Breathing
                                                  and state.can_reach_region("The Nether", player)  # Regeneration, Fire Resistance, gold nuggets
                                                  and state.can_reach_region("Village", player)  # Night Vision, Invisibility
-                                                 and state.can_reach_location("Bring Home the Beacon", player)
+                                                 and state.can_reach_location("Bring Home the Beacon", player)  # Resistance
                                                  and can_adventure(world, state, player)
-                                                 and has_explorer_maps(world, state, player)),  # Wind Charged
-            # Resistance
+                                                 and state.can_reach_region("Trial Chambers", player)  # Wind Charged
+                                                 ),
             "Bring Home the Beacon": lambda state: can_kill_wither(world, state, player)
                                                    and has_diamond_pickaxe(world, state, player)
                                                    and state.has("Progressive Resource Crafting", player, 2),
@@ -329,7 +325,7 @@ def get_rules_lookup(world, player: int):
                                                    and state.can_reach_region('The Nether', player)  # potion ingredients
                                                    and state.can_reach_region('Ocean Monument', player)  # Heart of the Sea, Dolphin's Grace, Mining Fatigue
                                                    and state.can_reach_region('Ancient City', player)  # Darkness
-                                                   and state.has("Fishing Rod", player) # Pufferfish, Nautilus Shells
+                                                   and state.has("Fishing Rod", player)  # Pufferfish, Nautilus Shells
                                                    and state.has("Archery", player)  # Spectral Arrows
                                                    and state.can_reach_location("Bring Home the Beacon", player)  # Haste
                                                    and state.can_reach_location("Hero of the Village", player)),  # Bad Omen, Hero of the Village
@@ -451,6 +447,7 @@ def get_rules_lookup(world, player: int):
                                       or (
                                            state.can_reach_location("Over-Overkill", player)
                                            and world.options.include_hard_advancements
+                                           and "Over-Overkill" not in world.options.exclude_locations.value
                                       ),
             "Librarian": lambda state: state.has("Enchanting", player),
             "Overpowered": lambda state: has_iron_ingots(world, state, player)
@@ -462,10 +459,7 @@ def get_rules_lookup(world, player: int):
                                       has_copper_ingots(world, state, player)
                                       and state.has('Campfire', player)
                                      )
-                                     or (
-                                      can_adventure(world, state, player)
-                                      and has_explorer_maps(world, state, player)
-                                     ),
+                                     or state.can_reach_region("Trial Chambers", player),
             "The Cutest Predator": lambda state: can_adventure(world, state, player)
                                                  and has_iron_ingots(world, state, player)
                                                  and state.has('Bucket', player),
@@ -520,9 +514,13 @@ def get_rules_lookup(world, player: int):
                                        and has_iron_ingots(world, state, player)
                                        and state.has("Progressive Tools", player, 2),
             "When the Squad Hops into Town": lambda state: can_adventure(world, state, player)
-                                                           and state.has("Lead", player),
+                                                           and state.has("Lead", player)
+                                                           and state.has("Bucket", player)
+                                                           and has_iron_ingots(world, state, player),
             "With Our Powers Combined!": lambda state: can_adventure(world, state, player)
-                                                       and state.has("Lead", player),
+                                                       and state.has("Lead", player)
+                                                       and state.has("Bucket", player)
+                                                       and has_iron_ingots(world, state, player),
             "You've Got a Friend in Me": lambda state: state.can_reach_region('Pillager Outpost', player)
                                                        or (
                                                            basic_combat(world, state, player)
@@ -531,7 +529,7 @@ def get_rules_lookup(world, player: int):
             "Smells Interesting": lambda state: can_excavate(world, state, player),
             "Little Sniffs": lambda state: can_excavate(world, state, player),
             "Planting the Past": lambda state: can_excavate(world, state, player),
-            "Crafting a New Look": lambda state: has_iron_ingots(world, state, player) # Maybe streamline this one
+            "Crafting a New Look": lambda state: has_iron_ingots(world, state, player)  # Maybe streamline this one
                                                  and (
                                                      fortress_loot(world, state, player)
                                                      or (
@@ -572,10 +570,8 @@ def get_rules_lookup(world, player: int):
                                                  ),
             "Smithing with Style": lambda state: can_excavate(world, state, player)  # Wayfinder Armor Trim
                                                  and fortress_loot(world, state, player)  # Rib Armor Trim
-                                                 and has_explorer_maps(world, state, player)  # Vex and Tide Armor Trims
                                                  and state.can_reach_region("Bastion Remnant", player)  # Snout Armor Trim
                                                  and state.can_reach_region("End City", player)  # Spire Armor Trim
-                                                 and state.has("Progressive Tools", player, 2)  # Ward and Silence Armor Trims; Compass for Explorer Maps
                                                  and (
                                                    (  # Water Breathing Potions
                                                     state.has("Fishing Rod", player)
@@ -586,7 +582,7 @@ def get_rules_lookup(world, player: int):
                                                     and can_enchant(world, state, player)  # Respiration
                                                    )
                                                  )
-                                                 and state.can_reach_region("Woodland Mansion", player) # Vex Armor Trim
+                                                 and state.can_reach_region("Woodland Mansion", player)  # Vex Armor Trim
                                                  and state.can_reach_region("Ancient City", player)  # Ward and Silence Armor Trims
                                                  and state.can_reach_region("Trail Ruins", player)
                                                  and state.can_reach_region("Ocean Monument", player),  # Tide Armor Trim
@@ -611,17 +607,9 @@ def get_rules_lookup(world, player: int):
                                          and has_copper_ingots(world, state, player)
                                          and state.has("Brush", player),
             "The Whole Pack": lambda state: can_adventure(world, state, player),
-            "Minecraft: Trial(s) Edition": lambda state: can_adventure(world, state, player)
-                                                         and has_explorer_maps(world, state, player),
-            "Under Lock and Key": lambda state: can_adventure(world, state, player)
-                                                and has_explorer_maps(world, state, player)
-                                                and basic_combat(world, state, player),
-            "Blowback": lambda state: can_adventure(world, state, player)
-                                      and has_explorer_maps(world, state, player)
-                                      and basic_combat(world, state, player),
-            "Who Needs Rockets?": lambda state: can_adventure(world, state, player)
-                                                and has_explorer_maps(world, state, player)
-                                                and basic_combat(world, state, player),
+            "Under Lock and Key": lambda state: basic_combat(world, state, player),
+            "Blowback": lambda state: basic_combat(world, state, player),
+            "Who Needs Rockets?": lambda state: basic_combat(world, state, player),
             "Crafters Crafting Crafters": lambda state: has_iron_ingots(world, state, player)
                                                         and state.has("Progressive Tools", player, 2),
             "Lighten Up": lambda state: (
@@ -629,10 +617,7 @@ def get_rules_lookup(world, player: int):
                                          and state.has("Progressive Tools", player, 2)
                                          and state.has("Progressive Resource Crafting", player, 2)
                                         )
-                                        or (
-                                         can_adventure(world, state, player)
-                                         and has_explorer_maps(world, state, player)
-                                        ),
+                                        or state.can_reach_region("Trial Chambers", player),
             "Over-Overkill": lambda state: ominous_vaults(world, state, player),
             "Revaulting": lambda state: ominous_vaults(world, state, player),
             "Stay Hydrated!": lambda state: state.can_reach_region("The Nether", player)

--- a/worlds/minecraft/Rules.py
+++ b/worlds/minecraft/Rules.py
@@ -490,7 +490,12 @@ def get_rules_lookup(world, player: int):
                                              and state.has("Saddle", player),
             "Sound of Music": lambda state: state.has("Progressive Tools", player, 2)
                                             and has_iron_ingots(world, state, player)
-                                            and basic_combat(world, state, player),
+                                            and can_adventure(world, state, player)
+                                            and (
+                                              basic_combat(world, state, player)
+                                              or state.can_reach_region("The Nether", player)
+                                              or state.can_reach_region("Ancient City", player)
+                                            ),
             "Star Trader": lambda state: has_iron_ingots(world, state, player)
                                          and state.has('Bucket', player)
                                          and (
@@ -504,7 +509,10 @@ def get_rules_lookup(world, player: int):
                                            and has_iron_ingots(world, state, player)
                                            and (
                                                state.can_reach_region('Pillager Outpost', player)
-                                               or state.can_reach_region('Woodland Mansion', player)
+                                               or (
+                                                   basic_combat(world, state, player)
+                                                   and state.can_reach_region('Woodland Mansion', player)
+                                               )
                                             ),
             "Bukkit Bukkit": lambda state: state.has("Bucket", player)
                                            and has_iron_ingots(world, state, player)

--- a/worlds/minecraft/Rules.py
+++ b/worlds/minecraft/Rules.py
@@ -89,7 +89,7 @@ def overworld_villager(world: "MinecraftWorld", state: CollectionState, player: 
                 ))
     elif village_region == 'The End':
         return state.can_reach_location('Zombie Doctor', player)
-    return state.can_reach_region('Village', player)
+    return state.can_reach_region('Village', player) or state.can_reach_location('Zombie Doctor', player)
 
 
 def enter_stronghold(world: "MinecraftWorld", state: CollectionState, player: int) -> bool:
@@ -325,6 +325,7 @@ def get_rules_lookup(world, player: int):
                                                    and state.can_reach_region('The Nether', player)  # potion ingredients
                                                    and state.can_reach_region('Ocean Monument', player)  # Heart of the Sea, Dolphin's Grace, Mining Fatigue
                                                    and state.can_reach_region('Ancient City', player)  # Darkness
+                                                   and state.can_reach_region('Trial Chambers', player)  # Wind Charged
                                                    and state.has("Fishing Rod", player)  # Pufferfish, Nautilus Shells
                                                    and state.has("Archery", player)  # Spectral Arrows
                                                    and state.can_reach_location("Bring Home the Beacon", player)  # Haste
@@ -373,17 +374,18 @@ def get_rules_lookup(world, player: int):
                                           or state.can_reach_region('Village', player),
             "You Need a Mint": lambda state: can_respawn_ender_dragon(world, state, player)
                                              and has_bottle(world, state, player),
-            "Monsters Hunted": lambda state: can_respawn_ender_dragon(world, state, player) # Ghast, Hoglin, Magma Cube, Piglin
+            "Monsters Hunted": lambda state: can_respawn_ender_dragon(world, state, player)  # Ghast, Hoglin, Magma Cube, Piglin
                                              and can_kill_ender_dragon(world, state, player)  # Ender Dragon, Enderman, Endermite, Silverfish
-                                             and can_kill_wither(world, state, player) # Blaze, Wither, Wither Skeleton, Zombified Piglin
+                                             and can_kill_wither(world, state, player)  # Blaze, Wither, Wither Skeleton, Zombified Piglin
                                              and complete_raid(world, state, player)  # Ravagers; Pillager Outposts
-                                             and state.can_reach_region('Bastion Remnant', player)
-                                             and state.can_reach_region('End City', player) # Piglin Brute; Shulker
+                                             and state.can_reach_region('Bastion Remnant', player)  # Piglin Brute
+                                             and state.can_reach_region('End City', player)  # Shulker
+                                             and state.can_reach_region('Trial Chambers', player)  # Breeze
                                              and state.has("Lead", player)  # Zoglins
-                                             and state.can_reach_region('Ocean Monument', player) # Drowned
+                                             and state.can_reach_region('Ocean Monument', player)  # Drowned
                                              and (
-                                                 (can_brew_potions(world, state, player) and state.has("Fishing Rod", player)) # Water Breathing Potions for Elder Guardian, Guardian
-                                                 or (can_enchant(world, state, player) and state.has("Bucket", player)) # Aqua Affinity/Respiration and Milk/Axolotls for Elder Guardian, Guardian
+                                                 (can_brew_potions(world, state, player) and state.has("Fishing Rod", player))  # Water Breathing Potions for Elder Guardian, Guardian
+                                                 or (can_enchant(world, state, player) and state.has("Bucket", player))  # Aqua Affinity/Respiration and Milk/Axolotls for Elder Guardian, Guardian
                                              ),
             "Enchanter": lambda state: can_enchant(world, state, player),
             "Voluntary Exile": lambda state: basic_combat(world, state, player),
@@ -547,16 +549,8 @@ def get_rules_lookup(world, player: int):
                                                      or (
                                                          state.can_reach_region("Ocean Monument", player)
                                                          and basic_combat(world, state, player)
-                                                         and (
-                                                             (
-                                                                 state.has("Fishing Rod", player)
-                                                                 and can_enchant(world, state, player)
-                                                             )
-                                                             or (
-                                                                 state.has("Bucket", player)
-                                                                 and can_brew_potions(world, state, player)
-                                                             )
-                                                         )
+                                                         and state.has("Bucket", player)
+                                                         and can_enchant(world, state, player)
                                                      )
                                                      or (
                                                          state.can_reach_region("Woodland Mansion", player)

--- a/worlds/minecraft/data/items.json
+++ b/worlds/minecraft/data/items.json
@@ -51,7 +51,8 @@
 		"Structure Compass (Ocean Monument)",
 		"Structure Compass (Woodland Mansion)",
 		"Structure Compass (Ancient City)",
-		"Structure Compass (Trail Ruins)"
+		"Structure Compass (Trail Ruins)",
+		"Structure Compass (Trial Chambers)"
 	],
 	"progression_items": [
 		"Archery",
@@ -87,7 +88,8 @@
 		"Structure Compass (Ocean Monument)",
 		"Structure Compass (Woodland Mansion)",
 		"Structure Compass (Ancient City)",
-		"Structure Compass (Trail Ruins)"
+		"Structure Compass (Trail Ruins)",
+		"Structure Compass (Trial Chambers)"
 	],
 	"useful_items": [
 		"Sharpness III Book",

--- a/worlds/minecraft/data/locations.json
+++ b/worlds/minecraft/data/locations.json
@@ -188,6 +188,7 @@
             "Time to Strike!",
             "Cow Tipper",
             "When Pigs Fly",
+            "Overkill",
             "Librarian",
             "Wax On",
             "Wax Off",
@@ -211,10 +212,6 @@
             "Shear Brilliance",
             "Good as New",
             "The Whole Pack",
-            "Minecraft: Trial(s) Edition",
-            "Under Lock and Key",
-            "Blowback",
-            "Who Needs Rockets?",
             "Crafters Crafting Crafters",
             "Lighten Up",
             "Stay Hydrated!",
@@ -262,14 +259,11 @@
             "Into Fire",
             "Beaconator",
             "Withering Heights",
-            "A Terrible Fortress",
-            "Overkill"
+            "A Terrible Fortress"
         ],
         "Pillager Outpost": [
             "Who's the Pillager Now?",
-            "Voluntary Exile",
-            "Over-Overkill",
-            "Revaulting"
+            "Voluntary Exile"
         ],
         "Bastion Remnant": [
             "War Pigs",
@@ -295,6 +289,14 @@
         ],
         "Trail Ruins": [
             "Is It a Bird?"
+        ],
+        "Trial Chambers": [
+            "Minecraft: Trial(s) Edition",
+            "Under Lock and Key",
+            "Blowback",
+            "Who Needs Rockets?",
+            "Over-Overkill",
+            "Revaulting"
         ]
     }
 }   

--- a/worlds/minecraft/data/regions.json
+++ b/worlds/minecraft/data/regions.json
@@ -1,7 +1,7 @@
 {
     "regions": [
         ["Menu", ["New World"]],
-        ["Overworld", ["Nether Portal", "End Portal", "Overworld Structure 1", "Overworld Structure 2", "Ocean", "Dark Forest", "Deep Dark", "Ruins"]],
+        ["Overworld", ["Nether Portal", "End Portal", "Overworld Structure 1", "Overworld Structure 2", "Ocean", "Dark Forest", "Deep Dark", "Ruins", "Underground"]],
         ["The Nether", ["Nether Structure 1", "Nether Structure 2"]],
         ["The End", ["The End Structure"]],
         ["Village", []],
@@ -12,7 +12,8 @@
         ["Ocean Monument", []],
         ["Woodland Mansion", []],
         ["Ancient City", []],
-        ["Trail Ruins", []]
+        ["Trail Ruins", []],
+        ["Trial Chambers", []]
     ],
     "mandatory_connections": [
         ["New World", "Overworld"],
@@ -21,7 +22,8 @@
         ["Ocean", "Ocean Monument"],
         ["Dark Forest", "Woodland Mansion"],
         ["Deep Dark", "Ancient City"],
-        ["Ruins", "Trail Ruins"]
+        ["Ruins", "Trail Ruins"],
+        ["Underground", "Trial Chambers"]
     ],
     "default_connections": [
         ["Overworld Structure 1", "Village"],

--- a/worlds/minecraft/docs/en_Minecraft.md
+++ b/worlds/minecraft/docs/en_Minecraft.md
@@ -53,6 +53,7 @@ or after completing both conditions.
 * Campfire
     * Campfire
     * Soul Campfire
+* Saddle
 * Spyglass
 * Lead
 * Brush
@@ -114,4 +115,6 @@ or after completing both conditions.
         * Anvil
         * Emerald
         * Emerald Block
+        * Copper Ingot
         * Copper Block
+        * Resin Block

--- a/worlds/minecraft/docs/en_Minecraft.md
+++ b/worlds/minecraft/docs/en_Minecraft.md
@@ -117,4 +117,5 @@ or after completing both conditions.
         * Emerald Block
         * Copper Ingot
         * Copper Block
+        * Resin Clump
         * Resin Block

--- a/worlds/minecraft/test/TestAdvancements.py
+++ b/worlds/minecraft/test/TestAdvancements.py
@@ -1160,12 +1160,12 @@ class TestAdvancements(MCTestBase):
         self.run_location_tests([
             ["Wax Off", False, []],
             ["Wax Off", False, [], ["Progressive Tools"]],
-            ["Wax Off", False, [], ["Progressive Resource Crafting"]],
             ["Wax Off", False, [], ["Campfire", "Progressive Weapons"]],
-            ["Wax Off", False, ["Progressive Tools"], ["Campfire", "Progressive Tools", "Progressive Tools"]],
-            ["Wax Off", True, ["Progressive Resource Crafting", "Progressive Tools", "Campfire"]],
-            ["Wax Off", True, ["Progressive Resource Crafting", "Progressive Tools", "Progressive Tools",
-                               "Progressive Weapons"]]
+            ["Wax Off", False, [], ["Campfire", "Progressive Resource Crafting"]],
+            ["Wax Off", False, [], ["Progressive Weapons", "Progressive Resource Crafting"]],
+            ["Wax Off", True, ["Progressive Tools", "Progressive Resource Crafting", "Campfire"]],
+            ["Wax Off", True, ["Progressive Tools", "Progressive Resource Crafting", "Progressive Weapons"]],
+            ["Wax Off", True, ["Progressive Tools", "Campfire", "Progressive Weapons"]]
             ])
 
     def test_42094(self):
@@ -1366,28 +1366,31 @@ class TestAdvancements(MCTestBase):
             ["Sneak 100", True, ["Progressive Tools", "Progressive Tools", "Progressive Weapons", "Progressive Resource Crafting"]],
             ])
 
-    # adventure, lead
+    # adventure, lead, bucket
     def test_42111(self):
         self.run_location_tests([
             ["When the Squad Hops into Town", False, []],
             ["When the Squad Hops into Town", False, [], ["Progressive Weapons"]],
-            ["When the Squad Hops into Town", False, [], ["Campfire", "Progressive Resource Crafting"]],
+            ["When the Squad Hops into Town", False, [], ["Progressive Resource Crafting"]],
+            ["When the Squad Hops into Town", False, [], ["Progressive Tools"]],
+            ["When the Squad Hops into Town", False, [], ["Bucket"]],
             ["When the Squad Hops into Town", False, [], ["Lead"]],
-            ["When the Squad Hops into Town", True, ["Progressive Weapons", "Lead", "Campfire"]],
-            ["When the Squad Hops into Town", True, ["Progressive Weapons", "Lead", "Progressive Resource Crafting"]],
+            ["When the Squad Hops into Town", True, ["Progressive Weapons", "Lead", "Progressive Resource Crafting",
+                                                     "Progressive Tools", "Bucket"]],
             ])
 
-    # adventure, lead, nether
+    # adventure, lead, bucket, nether
     def test_42112(self):
         self.run_location_tests([
             ["With Our Powers Combined!", False, []],
             ["With Our Powers Combined!", False, [], ["Lead"]],
-            ["With Our Powers Combined!", False, [], ["Bucket", "Progressive Tools"]],
+            ["With Our Powers Combined!", False, [], ["Bucket"]],
+            ["With Our Powers Combined!", False, [], ["Progressive Tools"]],
             ["With Our Powers Combined!", False, [], ["Flint and Steel"]],
             ["With Our Powers Combined!", False, [], ["Progressive Weapons"]],
             ["With Our Powers Combined!", False, [], ["Progressive Resource Crafting"]],
-            ["With Our Powers Combined!", True, ["Lead", "Progressive Weapons", "Progressive Resource Crafting", "Flint and Steel", "Progressive Tools", "Bucket"]],
-            ["With Our Powers Combined!", True, ["Lead", "Progressive Weapons", "Progressive Resource Crafting", "Flint and Steel", "Progressive Tools", "Progressive Tools", "Progressive Tools"]],
+            ["With Our Powers Combined!", True, ["Progressive Weapons", "Lead", "Progressive Resource Crafting",
+                                                 "Flint and Steel", "Progressive Tools", "Bucket"]],
             ])
 
     # pillager outpost -> adventure
@@ -1581,10 +1584,12 @@ class TestAdvancements(MCTestBase):
         self.run_location_tests([
             ["Minecraft: Trial(s) Edition", False, []],
             ["Minecraft: Trial(s) Edition", False, [], ["Progressive Weapons"]],
-            ["Minecraft: Trial(s) Edition", False, [], ["Progressive Resource Crafting"]],
-            ["Minecraft: Trial(s) Edition", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
-            ["Minecraft: Trial(s) Edition", True, ["Progressive Tools", "Progressive Tools",
-                                                   "Progressive Weapons", "Progressive Resource Crafting"]],
+            ["Minecraft: Trial(s) Edition", False, [], ["Progressive Tools"]],
+            ["Minecraft: Trial(s) Edition", False, [], ["Progressive Resource Crafting", "Campfire"]],
+            ["Minecraft: Trial(s) Edition", True, ["Progressive Tools", "Progressive Weapons",
+                                                   "Progressive Resource Crafting"]],
+            ["Minecraft: Trial(s) Edition", True, ["Progressive Tools", "Progressive Weapons",
+                                                   "Campfire"]],
             ])
 
     def test_42127(self):
@@ -1592,11 +1597,11 @@ class TestAdvancements(MCTestBase):
             ["Under Lock and Key", False, []],
             ["Under Lock and Key", False, [], ["Progressive Weapons"]],
             ["Under Lock and Key", False, [], ["Progressive Resource Crafting"]],
-            ["Under Lock and Key", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Under Lock and Key", False, [], ["Progressive Tools"]],
             ["Under Lock and Key", False, [], ["Progressive Armor", "Shield"]],
-            ["Under Lock and Key", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+            ["Under Lock and Key", True, ["Progressive Weapons", "Progressive Tools",
                                           "Progressive Resource Crafting", "Progressive Armor"]],
-            ["Under Lock and Key", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+            ["Under Lock and Key", True, ["Progressive Weapons", "Progressive Tools",
                                           "Progressive Resource Crafting", "Shield"]],
             ])
 
@@ -1605,11 +1610,11 @@ class TestAdvancements(MCTestBase):
             ["Blowback", False, []],
             ["Blowback", False, [], ["Progressive Weapons"]],
             ["Blowback", False, [], ["Progressive Resource Crafting"]],
-            ["Blowback", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Blowback", False, [], ["Progressive Tools"]],
             ["Blowback", False, [], ["Progressive Armor", "Shield"]],
-            ["Blowback", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+            ["Blowback", True, ["Progressive Weapons", "Progressive Tools",
                                 "Progressive Resource Crafting", "Progressive Armor"]],
-            ["Blowback", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+            ["Blowback", True, ["Progressive Weapons", "Progressive Tools",
                                 "Progressive Resource Crafting", "Shield"]],
             ])
 
@@ -1618,11 +1623,11 @@ class TestAdvancements(MCTestBase):
             ["Who Needs Rockets?", False, []],
             ["Who Needs Rockets?", False, [], ["Progressive Weapons"]],
             ["Who Needs Rockets?", False, [], ["Progressive Resource Crafting"]],
-            ["Who Needs Rockets?", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Who Needs Rockets?", False, [], ["Progressive Tools"]],
             ["Who Needs Rockets?", False, [], ["Progressive Armor", "Shield"]],
-            ["Who Needs Rockets?", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+            ["Who Needs Rockets?", True, ["Progressive Weapons", "Progressive Tools",
                                           "Progressive Resource Crafting", "Progressive Armor"]],
-            ["Who Needs Rockets?", True, ["Progressive Weapons", "Progressive Tools", "Progressive Tools",
+            ["Who Needs Rockets?", True, ["Progressive Weapons", "Progressive Tools",
                                           "Progressive Resource Crafting", "Shield"]],
             ])
 
@@ -1639,21 +1644,21 @@ class TestAdvancements(MCTestBase):
         self.run_location_tests([
             ["Lighten Up", False, []],
             ["Lighten Up", False, [], ["Progressive Weapons"]],
-            ["Lighten Up", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
-            ["Lighten Up", False, [], ["Progressive Resource Crafting"]],
-            ["Lighten Up", True, ["Progressive Tools", "Progressive Tools",
-                                  "Progressive Weapons", "Progressive Resource Crafting"]],
+            ["Lighten Up", False, [], ["Progressive Tools"]],
+            ["Lighten Up", False, [], ["Progressive Resource Crafting", "Campfire"]],
+            ["Lighten Up", True, ["Progressive Tools", "Progressive Weapons", "Progressive Resource Crafting"]],
+            ["Lighten Up", True, ["Progressive Tools", "Progressive Weapons", "Campfire"]],
             ])
 
     def test_42132(self):
         self.run_location_tests([
             ["Over-Overkill", False, []],
             ["Over-Overkill", False, [], ["Progressive Resource Crafting"]],
-            ["Over-Overkill", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Over-Overkill", False, [], ["Progressive Tools"]],
             ["Over-Overkill", False, ["Progressive Weapons"], ["Progressive Weapons", "Progressive Weapons"]],
             ["Over-Overkill", False, [], ["Progressive Armor"]],
             ["Over-Overkill", False, [], ["Shield"]],
-            ["Over-Overkill", True, ["Progressive Resource Crafting", "Progressive Tools", "Progressive Tools",
+            ["Over-Overkill", True, ["Progressive Resource Crafting", "Progressive Tools",
                                      "Progressive Weapons", "Progressive Weapons", "Progressive Armor", "Shield"]],
             ])
 
@@ -1661,11 +1666,11 @@ class TestAdvancements(MCTestBase):
         self.run_location_tests([
             ["Revaulting", False, []],
             ["Revaulting", False, [], ["Progressive Resource Crafting"]],
-            ["Revaulting", False, ["Progressive Tools"], ["Progressive Tools", "Progressive Tools"]],
+            ["Revaulting", False, [], ["Progressive Tools"]],
             ["Revaulting", False, ["Progressive Weapons"], ["Progressive Weapons", "Progressive Weapons"]],
             ["Revaulting", False, [], ["Progressive Armor"]],
             ["Revaulting", False, [], ["Shield"]],
-            ["Revaulting", True, ["Progressive Resource Crafting", "Progressive Tools", "Progressive Tools",
+            ["Revaulting", True, ["Progressive Resource Crafting", "Progressive Tools",
                                   "Progressive Weapons", "Progressive Weapons", "Progressive Armor", "Shield"]],
             ])
 

--- a/worlds/minecraft/test/TestAdvancements.py
+++ b/worlds/minecraft/test/TestAdvancements.py
@@ -657,10 +657,17 @@ class TestAdvancements(MCTestBase):
             ["Monsters Hunted", False, [], ['Archery']],
             ["Monsters Hunted", False, [], ['Enchanting']],
             ["Monsters Hunted", False, [], ['Lead']],
-            ["Monsters Hunted", True, ['Progressive Resource Crafting', 'Progressive Weapons', 'Progressive Weapons', 'Progressive Tools',
-                                       'Flint and Steel', 'Bucket', 'Progressive Tools', 'Progressive Tools', 'Progressive Weapons',
-                                       'Progressive Armor', 'Progressive Armor', 'Brewing', 'Bottles', 'Enchanting',
-                                       'Shield', 'Archery', 'Lead', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls']],
+            ["Monsters Hunted", False, [], ['Bucket', 'Fishing Rod']],
+            ["Monsters Hunted", True, ['Progressive Weapons', 'Progressive Weapons', 'Progressive Weapons', 'Lead',
+                                       'Progressive Resource Crafting', 'Flint and Steel', 'Brewing', 'Bottles',
+                                       'Progressive Tools', 'Progressive Tools', 'Progressive Tools', 'Enchanting',
+                                       'Progressive Armor', 'Progressive Armor', 'Shield', 'Archery', 'Bucket',
+                                       '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls']],
+            ["Monsters Hunted", True, ['Progressive Weapons', 'Progressive Weapons', 'Progressive Weapons', 'Lead',
+                                       'Progressive Resource Crafting', 'Flint and Steel', 'Brewing', 'Bottles',
+                                       'Progressive Tools', 'Progressive Tools', 'Progressive Tools', 'Enchanting',
+                                       'Progressive Armor', 'Progressive Armor', 'Shield', 'Archery', 'Fishing Rod',
+                                       '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls']],
             ])
 
     def test_42049(self):

--- a/worlds/minecraft/test/TestAdvancements.py
+++ b/worlds/minecraft/test/TestAdvancements.py
@@ -1314,9 +1314,7 @@ class TestAdvancements(MCTestBase):
             ["Sound of Music", False, [], ["Progressive Tools"]],
             ["Sound of Music", False, [], ["Progressive Resource Crafting"]],
             ["Sound of Music", False, [], ["Progressive Weapons"]],
-            ["Sound of Music", False, [], ["Progressive Armor", "Shield"]],
-            ["Sound of Music", True, ["Progressive Tools", "Progressive Tools", "Progressive Resource Crafting", "Progressive Weapons", "Progressive Armor"]],
-            ["Sound of Music", True, ["Progressive Tools", "Progressive Tools", "Progressive Resource Crafting", "Progressive Weapons", "Shield"]],
+            ["Sound of Music", True, ["Progressive Tools", "Progressive Tools", "Progressive Resource Crafting", "Progressive Weapons"]],
             ])
 
     # bucket, nether, villager


### PR DESCRIPTION
## What is this fixing or adding?
Adds support for Trial Chamber Structure Compasses, and refactors logic to use them instead of Explorer Maps.
Also adds Bucket + Iron Ingots requirements to `When the Squad Hops into Town` and `With Our Powers Combined!`, moves `Overkill` to the Overworld region, stops `Over-Overkill` from being an expected method of achieving `Overkill` when `Over-Overkill` is explicitly excluded, and updates some documentation.

## How was this tested?
Ran unit tests, ran a few test gens.
