### PR TITLE
Add Shulker Boxes to Item Pool

### DIFF
--- a/worlds/minecraft/data/items.json
+++ b/worlds/minecraft/data/items.json
@@ -92,7 +92,8 @@
 	"useful_items": [
 		"Sharpness III Book",
 		"Looting III Book",
-		"Infinity Book"
+		"Infinity Book",
+		"Shulker Box"
 	],
 	"trap_items": [
 		"Bee Trap"
@@ -122,6 +123,7 @@
 	    "Infinity Book": 1,
 	    "3 Ender Pearls": 4,
 	    "Saddle": 1,
+	    "Shulker Box": 4,
 	    "Spyglass": 1,
 	    "Lead": 1,
 	    "Brush": 1


### PR DESCRIPTION
## What is this fixing or adding?
Reclassifies Shulker Boxes as `Useful` items and adds 4 of them to the item pool.
The count is fairly arbitrary and probably worth playtesting.

## How was this tested?
I generated a game and saw that the Shulker Boxes were added in the spoiler log.