### PR TITLE
Minecraft: Update Item+Location ID System

### DIFF
--- a/worlds/minecraft/Constants.py
+++ b/worlds/minecraft/Constants.py
@@ -1,24 +1,19 @@
 import json
 import pkgutil
 
+
 def load_data_file(*args) -> dict:
     fname = "/".join(["data", *args])
     return json.loads(pkgutil.get_data(__name__, fname).decode())
 
-# For historical reasons, these values are different.
-# They remain different to ensure datapackage consistency.
-# Do not separate other games' location and item IDs like this.
-item_id_offset: int 	= 45000
-location_id_offset: int = 42000
 
 item_info = load_data_file("items.json")
-item_name_to_id = {name: item_id_offset + index \
-	for index, name in enumerate(item_info["all_items"])}
-item_name_to_id["Bee Trap"] = item_id_offset + 100  # historical reasons
+item_name_to_id = {name: index \
+                   for index, name in enumerate(item_info["all_items"], start=1)}
 
 location_info = load_data_file("locations.json")
-location_name_to_id = {name: location_id_offset + index \
-	for index, name in enumerate(location_info["all_locations"])}
+location_name_to_id = {name: index \
+                       for index, name in enumerate(location_info["all_locations"], start=1)}
 
 exclusion_info = load_data_file("excluded_locations.json")
 

--- a/worlds/minecraft/data/items.json
+++ b/worlds/minecraft/data/items.json
@@ -2,7 +2,6 @@
 	"all_items": [
 		"Archery",
 		"Progressive Resource Crafting",
-		"Resource Blocks",
 		"Brewing",
 		"Enchanting",
 		"Bucket",

--- a/worlds/minecraft/data/items.json
+++ b/worlds/minecraft/data/items.json
@@ -55,7 +55,6 @@
 	"progression_items": [
 		"Archery",
 		"Progressive Resource Crafting",
-		"Resource Blocks",
 		"Brewing",
 		"Enchanting",
 		"Bucket",

--- a/worlds/minecraft/test/TestDataLoad.py
+++ b/worlds/minecraft/test/TestDataLoad.py
@@ -2,6 +2,7 @@ import unittest
 
 from .. import Constants
 
+
 class TestDataLoad(unittest.TestCase):
 
     def test_item_data(self):
@@ -25,7 +26,7 @@ class TestDataLoad(unittest.TestCase):
 
         # Every location has a region and every region's locations are in all_locations
         all_locations: set = set(location_info['all_locations'])
-        all_locs_2: set    = set()
+        all_locs_2: set = set()
         for v in location_info['locations_by_region'].values():
             all_locs_2.update(v)
         assert all_locations == all_locs_2
@@ -49,7 +50,7 @@ class TestDataLoad(unittest.TestCase):
         for v in region_info['mandatory_connections']:
             assert v[0] in all_entrances
             assert v[1] in all_regions
-            
+
         for v in region_info['default_connections']:
             assert v[0] in all_entrances
             assert v[1] in all_regions
@@ -57,4 +58,3 @@ class TestDataLoad(unittest.TestCase):
         for k, v in region_info['illegal_connections'].items():
             assert k in all_regions
             assert set(v) <= all_entrances
-


### PR DESCRIPTION
## What is this fixing or adding?
This changes the ID system for items and locations. Each Location and ID now starts at 1, and counts up from there. There are no offsets, and the trap offset is removed entirely.
This effects #5, #6 , and #7, though it does not incorporate those changes.


## How was this tested?
Ran a few test games with the [Minecraft mod ID changes](https://github.com/qixils/NeoForgeAP/tree/mc/1.21.8-newids) branch. Everything appeared to work properly.