### PR TITLE
Add support for creating items with multiple classifications

### DIFF
--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -152,11 +152,11 @@ class MinecraftWorld(World):
     def create_item(self, name: str) -> Item:
         item_class = ItemClassification.filler
         if name in Constants.item_info["progression_items"]:
-            item_class = ItemClassification.progression
-        elif name in Constants.item_info["useful_items"]:
-            item_class = ItemClassification.useful
-        elif name in Constants.item_info["trap_items"]:
-            item_class = ItemClassification.trap
+            item_class |= ItemClassification.progression
+        if name in Constants.item_info["useful_items"]:
+            item_class |= ItemClassification.useful
+        if name in Constants.item_info["trap_items"]:
+            item_class |= ItemClassification.trap
 
         return MinecraftItem(name, item_class, self.item_name_to_id.get(name, None), self.player)
 


### PR DESCRIPTION
## What is this fixing or adding?
Modifies Minecraft's `create_item` function to allow it to create items with multiple classifications.
This does not currently have any practical purpose but opens up the ability for items with multiple classifications to be added in the future, or for the existing items to be given multiple classifications.

## How was this tested?
Temporarily added an item to both the `progression_items` and `useful_items` groups, generated a game, triggered the item being sent with a command, and observed that it had both the `Progression` and `Useful` flags.
