### PR TITLE
Explicit Universal Tracker support for Minecraft

### DIFF
--- a/worlds/minecraft/Structures.py
+++ b/worlds/minecraft/Structures.py
@@ -1,5 +1,6 @@
 from . import Constants
 from typing import TYPE_CHECKING
+from Options import PlandoConnection
 if TYPE_CHECKING:
     from . import MinecraftWorld
 
@@ -27,16 +28,17 @@ def shuffle_structures(self: "MinecraftWorld") -> None:
         else: 
             raise Exception(f"Invalid connection: {exit} => {struct} for player {player} ({multiworld.player_name[player]})")
 
+    if self.using_ut:
+        self.options.plando_connections.value.clear()
+        for exit, struct in self.passthrough["structures"].items():
+            exit_name = exit
+            struct_name = struct
+            self.options.plando_connections.value.append(PlandoConnection(exit_name, struct_name, "both"))
+
     # Connect plando structures first
     if self.options.plando_connections:
         for conn in self.options.plando_connections:
             set_pair(conn.entrance, conn.exit)
-
-    # if self.using_ut:
-    #     self.options.plando_connections.value.clear()
-    #     for structs, exits in self.passthrough[""].items():
-    #         struct_name = ""
-    #         exit_name = ""
 
     # The algorithm tries to place the most restrictive structures first. This algorithm always works on the
     # relatively small set of restrictions here, but does not work on all possible inputs with valid configurations. 

--- a/worlds/minecraft/Structures.py
+++ b/worlds/minecraft/Structures.py
@@ -32,6 +32,12 @@ def shuffle_structures(self: "MinecraftWorld") -> None:
         for conn in self.options.plando_connections:
             set_pair(conn.entrance, conn.exit)
 
+    # if self.using_ut:
+    #     self.options.plando_connections.value.clear()
+    #     for structs, exits in self.passthrough[""].items():
+    #         struct_name = ""
+    #         exit_name = ""
+
     # The algorithm tries to place the most restrictive structures first. This algorithm always works on the
     # relatively small set of restrictions here, but does not work on all possible inputs with valid configurations. 
     if self.options.shuffle_structures:

--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -132,11 +132,11 @@ class MinecraftWorld(World):
     using_ut = bool
     passthrough = dict[str, Any]
     ut_can_gen_without_yaml = True
-    # tracker_world: ClassVar = ut_stuff.tracker_world
 
     def _get_mc_data(self) -> Dict[str, Any]:
         exits = [connection[0] for connection in Constants.region_info["default_connections"]]
         return {
+            # Mod data
             'world_seed': self.random.getrandbits(32),
             'seed_name': self.multiworld.seed_name,
             'player_name': self.player_name,
@@ -152,6 +152,8 @@ class MinecraftWorld(World):
             'death_link': bool(self.options.death_link.value),
             'starting_items': json.dumps(self.options.starting_items.value),
             'race': self.multiworld.is_race,
+
+            # Universal Tracker data
             'bosses_to_defeat': self.options.required_bosses.value,
             'shuffle_structures': self.options.shuffle_structures.value,
             'structure_compasses': self.options.structure_compasses.value,

--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -129,6 +129,11 @@ class MinecraftWorld(World):
     item_name_to_id = Constants.item_name_to_id
     location_name_to_id = Constants.location_name_to_id
 
+    using_ut = bool
+    passthrough = dict[str, Any]
+    ut_can_gen_without_yaml = True
+    # tracker_world: ClassVar = ut_stuff.tracker_world
+
     def _get_mc_data(self) -> Dict[str, Any]:
         exits = [connection[0] for connection in Constants.region_info["default_connections"]]
         return {
@@ -147,7 +152,32 @@ class MinecraftWorld(World):
             'death_link': bool(self.options.death_link.value),
             'starting_items': json.dumps(self.options.starting_items.value),
             'race': self.multiworld.is_race,
+            'bosses_to_defeat': self.options.required_bosses.value,
+            'shuffle_structures': self.options.shuffle_structures.value,
+            'structure_compasses': self.options.structure_compasses.value,
+            'combat_difficulty': self.options.combat_difficulty.value,
+            'include_hard_advancements': self.options.include_hard_advancements.value,
+            'include_unreasonable_advancements': self.options.include_unreasonable_advancements.value,
+            'include_postgame_advancements': self.options.include_postgame_advancements.value,
         }
+
+    def generate_early(self: "MinecraftWorld") -> None:
+        re_gen_passthrough = getattr(self.multiworld, "re_gen_passthrough", {})
+        if re_gen_passthrough and self.game in re_gen_passthrough:
+            self.using_ut = True
+            self.passthrough = re_gen_passthrough["Minecraft"]
+            self.options.advancement_goal.value = self.passthrough["advancement_goal"]
+            self.options.egg_shards_required.value = self.passthrough["egg_shards_required"]
+            self.options.required_bosses.value = self.passthrough["bosses_to_defeat"]
+            self.options.shuffle_structures.value = self.passthrough["shuffle_structures"]
+            self.options.structure_compasses.value = self.passthrough["structure_compasses"]
+            self.options.combat_difficulty.value = self.passthrough["combat_difficulty"]
+            self.options.include_hard_advancements.value = self.passthrough["include_hard_advancements"]
+            self.options.include_unreasonable_advancements.value = self.passthrough["include_unreasonable_advancements"]
+            self.options.include_postgame_advancements.value = self.passthrough["include_postgame_advancements"]
+            self.options.death_link.value = self.passthrough["death_link"]
+        else:
+            self.using_ut = False
 
     def create_item(self, name: str) -> Item:
         item_class = ItemClassification.filler
@@ -223,6 +253,11 @@ class MinecraftWorld(World):
 
     def get_filler_item_name(self) -> str:
         return get_junk_item_names(self.random, 1)[0]
+
+    # For UT
+    @staticmethod
+    def interpret_slot_data(slot_data: dict[str, Any]) -> dict[str, Any]:
+        return slot_data
 
 
 class MinecraftLocation(Location):

--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -170,6 +170,7 @@ class MinecraftWorld(World):
             self.passthrough = re_gen_passthrough["Minecraft"]
             self.options.advancement_goal.value = self.passthrough["advancement_goal"]
             self.options.egg_shards_required.value = self.passthrough["egg_shards_required"]
+            self.options.egg_shards_available.value = self.passthrough["egg_shards_available"]
             self.options.required_bosses.value = self.passthrough["bosses_to_defeat"]
             self.options.shuffle_structures.value = self.passthrough["shuffle_structures"]
             self.options.structure_compasses.value = self.passthrough["structure_compasses"]

--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -129,8 +129,8 @@ class MinecraftWorld(World):
     item_name_to_id = Constants.item_name_to_id
     location_name_to_id = Constants.location_name_to_id
 
-    using_ut = bool
-    passthrough = dict[str, Any]
+    using_ut: bool
+    passthrough: dict[str, Any]
     ut_can_gen_without_yaml = True
 
     def _get_mc_data(self) -> Dict[str, Any]:


### PR DESCRIPTION
## What is this fixing or adding?
Adds explicit support for the [Universal Tracker](https://github.com/FarisTheAncient/Archipelago/blob/tracker/worlds/tracker/docs/setup.md) to Minecraft.
UT recreates the chosen options from slot data so that a YAML is not required for it, and ensures that the options will match the ones used if there is any randomness in the YAML.
It also supports Structure Shuffle by getting the chosen structures from slot data and using Plando Connections to connect the correct entrances to them.

## How was this tested?
Generated some test games with random options and saw that the rules matched the results in the spoiler log.
Ensured that the client didn't crash and burn due to the additional slot data by connecting to a room with it.