### PR TITLE
Add new YAML option: Immediate Respawn

### DIFF
--- a/worlds/minecraft/Options.py
+++ b/worlds/minecraft/Options.py
@@ -93,6 +93,10 @@ class SendDefeatedMobs(Toggle):
     """Send killed mobs to other Minecraft worlds which have this option enabled."""
     display_name = "Send Defeated Mobs"
 
+class ImmediateRespawn(DefaultOnToggle):
+    """Choose whether to respawn immediately on death, or to be put into the game over screen."""
+    display_name = "Immediate Respawn"
+
 
 class StartingItems(OptionList):
     """Start with these items. Each entry should be of this format: {item: "item_name", amount: #}
@@ -139,5 +143,6 @@ class MinecraftOptions(PerGameCommonOptions):
     include_postgame_advancements: PostgameAdvancements
     bee_traps: BeeTraps
     send_defeated_mobs: SendDefeatedMobs
+    immediate_respawn: ImmediateRespawn
     death_link: DeathLink
     starting_items: StartingItems

--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -152,6 +152,7 @@ class MinecraftWorld(World):
             'death_link': bool(self.options.death_link.value),
             'starting_items': json.dumps(self.options.starting_items.value),
             'race': self.multiworld.is_race,
+            'immediate_respawn': bool(self.options.immediate_respawn.value),
 
             # Universal Tracker data
             'bosses_to_defeat': self.options.required_bosses.value,
@@ -179,6 +180,7 @@ class MinecraftWorld(World):
             self.options.include_unreasonable_advancements.value = self.passthrough["include_unreasonable_advancements"]
             self.options.include_postgame_advancements.value = self.passthrough["include_postgame_advancements"]
             self.options.death_link.value = self.passthrough["death_link"]
+            self.options.immediate_respawn.value = self.passthrough["immediate_respawn"]
         else:
             self.using_ut = False
 


### PR DESCRIPTION
## What is this fixing or adding?
This adds a new option to the YAML, default to true: Immediate Respawn.
On true, it sets the Immediate Respawn gamerule to true on start, keeping current behavior.
On false, it sets it to false, making the player decide whether to respawn or not in the game over menu, restoring old behavior

## How was this tested?
Genned a few worlds, and preceded to experience a critical lack of self-preservation instincts. Worlds kept the behavior as described above when enabled. This will work on the 26.1 branch and above.

## If this makes graphical changes, please attach screenshots.
<img width="1499" height="883" alt="respawnoption" src="https://github.com/user-attachments/assets/bfae7a69-4af0-47be-bbca-dbb33448cb45" />
